### PR TITLE
Implement fix for templates

### DIFF
--- a/packages/frontend/src/components/elements/select/select.tsx
+++ b/packages/frontend/src/components/elements/select/select.tsx
@@ -13,6 +13,7 @@ interface SelectProps {
   handleOnChange?(event: React.ChangeEvent<HTMLSelectElement>): void;
   testId?: string;
   placeholder?: string;
+  shouldUnregister?: boolean;
 }
 
 export interface Option {
@@ -31,6 +32,7 @@ export const Select = ({
   isDisabled = false,
   placeholder = 'Select option',
   handleOnChange = () => {},
+  shouldUnregister,
 }: SelectProps): JSX.Element => {
   const { register } = useFormContext();
 
@@ -44,7 +46,7 @@ export const Select = ({
     <div className={className}>
       <label
         htmlFor={id}
-        className="block text-xs tracking-tight text-black/75 uppercase font-medium"
+        className="block text-xs font-medium tracking-tight uppercase text-black/75"
       >
         {children}
         <select
@@ -58,7 +60,7 @@ export const Select = ({
             disabled: isDisabled,
             onChange: handleChange,
             required: isRequired,
-            shouldUnregister: false,
+            shouldUnregister,
           })}
         >
           <option value="" disabled>

--- a/packages/frontend/src/pages/settings/templates/template.form.tsx
+++ b/packages/frontend/src/pages/settings/templates/template.form.tsx
@@ -165,13 +165,23 @@ export const TemplateForm = ({
           </Input>
           {(templateVisibility === TransactionTypeEnum.Expense ||
             templateVisibility === TransactionTypeEnum.Transfer) && (
-            <Select id="fromAccount" options={accountOptions} isRequired>
+            <Select
+              id="fromAccount"
+              options={accountOptions}
+              isRequired
+              shouldUnregister
+            >
               From Account
             </Select>
           )}
           {(templateVisibility === TransactionTypeEnum.Income ||
             templateVisibility === TransactionTypeEnum.Transfer) && (
-            <Select id="toAccount" options={accountOptions} isRequired>
+            <Select
+              id="toAccount"
+              options={accountOptions}
+              isRequired
+              shouldUnregister
+            >
               To Account
             </Select>
           )}


### PR DESCRIPTION
## Describe your changes
This pull request primarily focuses on the addition of a new `shouldUnregister` property to the `Select` component and its usage in the `TemplateForm` component. A minor stylistic change has also been made to the `className` property of a `label` element in the `Select` component.

Addition of new property:

* [`packages/frontend/src/components/elements/select/select.tsx`](diffhunk://#diff-0e1844712fe1939e7e014a3451c90c6d13a87d6a862e7c4101f5f5e9b8e72c8fR16): The `SelectProps` interface now includes a new optional property `shouldUnregister`. This property is also now being used in the `Select` component. The `shouldUnregister` attribute in the `useFormContext` hook has been updated to use the new property. [[1]](diffhunk://#diff-0e1844712fe1939e7e014a3451c90c6d13a87d6a862e7c4101f5f5e9b8e72c8fR16) [[2]](diffhunk://#diff-0e1844712fe1939e7e014a3451c90c6d13a87d6a862e7c4101f5f5e9b8e72c8fR35) [[3]](diffhunk://#diff-0e1844712fe1939e7e014a3451c90c6d13a87d6a862e7c4101f5f5e9b8e72c8fL61-R63)

Stylistic change:

* [`packages/frontend/src/components/elements/select/select.tsx`](diffhunk://#diff-0e1844712fe1939e7e014a3451c90c6d13a87d6a862e7c4101f5f5e9b8e72c8fL47-R49): The order of the class names in the `className` property of a `label` element has been rearranged.

Usage of new property:

* [`packages/frontend/src/pages/settings/templates/template.form.tsx`](diffhunk://#diff-3d64f2e5285a46300d73b2e8a6c4ccdc43ffe0683fe72f0c5cf7656dd81e74a7L168-R184): The `Select` component now uses the `shouldUnregister` property in the `TemplateForm` component.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

